### PR TITLE
Implementation of the getSamples function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Slice file into a smaller wav chunk:
 
 The success callback is passed the resulting slice as an ArrayBuffer - this buffer represents a new WAVE file of the slice (with WAVE headers).
 
+Read samples from a wav file:
+
+    var fileInput = document.getElementById('fileInput');
+    var file = fileInput.files[0];
+    var wavFile = new wav(file);
+    
+    wavFile.onloadend = function () {
+        //Print out all the samples
+        console.log(wavFile.dataSamples);
+    };
+
+
 Example
 -----
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Read samples from a wav file:
     var wavFile = new wav(file);
     
     wavFile.onloadend = function () {
+        //Load all samples
+        wavFile.getSamples();
         //Print out all the samples
         console.log(wavFile.dataSamples);
     };

--- a/wav.js
+++ b/wav.js
@@ -15,6 +15,9 @@ NOTE: Does not auto-correct:
 @author  David Lindkvist
 @twitter ffdead
 
+@author Thatcher Chamberlin
+Added code for the getSamples function
+
 */
 
 
@@ -38,6 +41,8 @@ function wav(file) {
   // original File and loaded ArrayBuffer
   this.file          = file instanceof Blob ? file : undefined;
   this.buffer        = file instanceof ArrayBuffer ? file : undefined;;
+  
+  this.dataBuffer	 = file instanceof ArrayBuffer ? file : undefined;;
   
   // format
   this.chunkID       = undefined; // must be RIFF
@@ -75,7 +80,7 @@ wav.prototype.peek = function () {
   
   // only load the first 44 bytes of the header
   var headerBlob = this.sliceFile(0, 44);
-  reader.readAsArrayBuffer(headerBlob);
+  reader.readAsArrayBuffer(this.file);
   
   reader.onloadend = function() {  
     that.buffer = this.result;
@@ -87,6 +92,7 @@ wav.prototype.parseArrayBuffer = function () {
   try {
     this.parseHeader();
     this.parseData();
+    this.getSamples();
     this.readyState = this.DONE;
   }
   catch (e) {
@@ -185,16 +191,16 @@ wav.prototype.slice = function (start, length, callback) {
 
 /*
  * do we need direct access to  samples?
- *
+ * Yes, definitely
+ * Samples can be accessed from the dataSamples variable
+ */
 wav.prototype.getSamples = function () {
-
-  // TODO load data chunk into buffer
+  
   if (this.bitsPerSample === 8)
-    this.dataSamples = new Uint8Array(this.buffer, 44, chunkSize/this.blockAlign);
+    this.dataSamples = new Uint8Array(this.buffer, 44, this.dataLength/this.blockAlign);
   else if (this.bitsPerSample === 16)
-    this.dataSamples = new Int16Array(this.buffer, 44, chunkSize/this.blockAlign);
+    this.dataSamples = new Int16Array(this.buffer, 44, this.dataLength/this.blockAlign);
 }
-*/
 
 /**
  * Reads slice from buffer as String

--- a/wav.js
+++ b/wav.js
@@ -92,7 +92,6 @@ wav.prototype.parseArrayBuffer = function () {
   try {
     this.parseHeader();
     this.parseData();
-    this.getSamples();
     this.readyState = this.DONE;
   }
   catch (e) {


### PR DESCRIPTION
The `getSamples()` function was left empty in the origin branch. I used wav.js for a project of mine and implemented the function. The samples from the .wav are loaded into the array `this.dataSamples` when `this.getSamples()` is called.
